### PR TITLE
remove log4j due to potential security vulnerability

### DIFF
--- a/lambda/pom.xml
+++ b/lambda/pom.xml
@@ -129,10 +129,5 @@
             <artifactId>commons-collections4</artifactId>
             <version>4.1</version>
         </dependency>
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
-        </dependency>
     </dependencies>
 </project>

--- a/lambda/src/main/resources/log4j.properties
+++ b/lambda/src/main/resources/log4j.properties
@@ -1,6 +1,0 @@
-log4j.rootLogger=WARN, A1
-log4j.appender.A1=org.apache.log4j.ConsoleAppender
-log4j.appender.A1.layout=org.apache.log4j.PatternLayout
-log4j.appender.A1.layout.ConversionPattern=%d [%t] %-5p %c -  %m%n
-log4j.logger.com.amazonaws=INFO
-log4j.logger.org.apache.http=INFO


### PR DESCRIPTION
*Issue*
CVE-2019-17571

*Description of changes:*
remove log4j
